### PR TITLE
Add Vue frontend and .NET backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # ScoreSite
+
+This repository contains a very small example of a website project with a Vue.js frontend and a C# .NET backend.
+
+```
+frontend/ - Simple Vue.js single page
+backend/  - Minimal ASP.NET Core API
+```
+
+## Running the frontend
+Open `frontend/index.html` in a browser. It loads Vue from a CDN and displays a greeting.
+
+## Running the backend
+You need the .NET SDK installed. Run the following command from the repository root:
+
+```bash
+dotnet run --project backend/ScoreSiteApi/ScoreSiteApi.csproj
+```
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,13 @@
+# ScoreSite Backend
+
+This directory contains a minimal ASP.NET Core Web API.
+
+## Running
+
+Use the .NET SDK to run the API:
+
+```bash
+dotnet run --project ScoreSiteApi/ScoreSiteApi.csproj
+```
+
+The API will start on the default port (usually 5000) and exposes a sample `WeatherForecast` endpoint at `/api/WeatherForecast`.

--- a/backend/ScoreSiteApi/Controllers/WeatherForecastController.cs
+++ b/backend/ScoreSiteApi/Controllers/WeatherForecastController.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ScoreSiteApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class WeatherForecastController : ControllerBase
+    {
+        [HttpGet]
+        public IEnumerable<string> Get()
+        {
+            return new[] { "Sunny", "Cloudy", "Rainy" };
+        }
+    }
+}

--- a/backend/ScoreSiteApi/Program.cs
+++ b/backend/ScoreSiteApi/Program.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();

--- a/backend/ScoreSiteApi/ScoreSiteApi.csproj
+++ b/backend/ScoreSiteApi/ScoreSiteApi.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,7 @@
+# ScoreSite Frontend
+
+This directory contains a simple Vue.js application.
+
+Open `index.html` in a browser to see the app running.
+
+The page loads Vue from a CDN and displays a message rendered by Vue.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ScoreSite</title>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+</head>
+<body>
+  <div id="app">{{ message }}</div>
+  <script>
+    const { createApp } = Vue;
+    createApp({
+      data() {
+        return {
+          message: 'Hello from Vue!'
+        };
+      }
+    }).mount('#app');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add minimal Vue.js frontend
- add minimal ASP.NET Core API backend
- update root README with instructions

## Testing
- `dotnet build backend/ScoreSiteApi/ScoreSiteApi.csproj` *(fails: `dotnet` not found)*